### PR TITLE
Introduce ability for separate error norm computation of field and fringe points

### DIFF
--- a/src/ExaTioga.cpp
+++ b/src/ExaTioga.cpp
@@ -50,7 +50,15 @@ void ExaTioga::init_stk(const YAML::Node& node)
 {
     m_stk.num_cell_vars() = m_amr.num_cell_vars();
     m_stk.num_node_vars() = m_amr.num_node_vars();
+    m_stk.field_sol() = m_amr.stk_sol();
+    m_stk.fringe_sol() = m_amr.amr_sol();
     m_stk.load_and_initialize_all(node["nalu_wind"]);
+
+    if(m_amr.stk_sol() != m_amr.amr_sol()) {
+        amrex::Print() << "WARNING: Analytical solution set for STK mesh and AMR mesh is not same. "
+                       << "May result in incorrect error norm computations."
+                       << std::endl;
+    }
 }
 
 void ExaTioga::execute(const YAML::Node& doc)

--- a/src/StkIface.h
+++ b/src/StkIface.h
@@ -48,7 +48,7 @@ public:
 
     void update_solution()
     {
-        tg_->update_solution(num_vars());
+        tg_->update_solution(num_cell_vars(), num_node_vars(), field_sol_, fringe_sol_);
     }
 
     void move_mesh(int nt)
@@ -81,8 +81,15 @@ public:
 
     const int num_vars() const { return ncell_vars_ + nnode_vars_; }
 
+    int& field_sol() { return field_sol_; }
+
+    int& fringe_sol() { return fringe_sol_; }
+
 private:
     void init_vars();
+
+    double get_sol(const double, const double, const double,
+        const int, const int);
 
     stk::ParallelMachine comm_;
     stk::mesh::MetaData meta_;
@@ -94,6 +101,9 @@ private:
 
     int ncell_vars_{0};
     int nnode_vars_{0};
+
+    int field_sol_{1};
+    int fringe_sol_{1};
 
     bool has_motion_{false};
 };

--- a/src/TiogaBlock.cpp
+++ b/src/TiogaBlock.cpp
@@ -525,8 +525,11 @@ double TiogaBlock::update_solution(const int ncellVars, const int nnodeVars, boo
         }
     }
 
-    rnorm /= static_cast<double>(counter * (ncellVars + nnodeVars));
-    return std::sqrt(rnorm);
+    if (counter > 0) {
+        rnorm /= static_cast<double>(counter * (ncellVars + nnodeVars));
+        rnorm = std::sqrt(rnorm);
+    }
+    return rnorm;
 }
 
 double TiogaBlock::get_sol(const double x, const double y, const double z,

--- a/src/TiogaBlock.h
+++ b/src/TiogaBlock.h
@@ -102,7 +102,7 @@ public:
   void register_solution(TIOGA::tioga&, const int);
 
   //! Update solution field and return error norm
-  double update_solution(const int);
+  double update_solution(const int, const bool);
 
   // Accessors
 

--- a/src/TiogaBlock.h
+++ b/src/TiogaBlock.h
@@ -102,7 +102,7 @@ public:
   void register_solution(TIOGA::tioga&, const int);
 
   //! Update solution field and return error norm
-  double update_solution(const int, const bool);
+  double update_solution(const int, const int, const bool, const int);
 
   // Accessors
 
@@ -150,6 +150,11 @@ private:
   /** Generate the element data structure and connectivity information to send to TIOGA
    */
   void process_elements();
+
+  /** Compute analytical solution based on solution type
+   */
+  double get_sol(const double, const double, const double,
+      const int, const int);
 
   //! Reference to the STK Mesh MetaData object
   stk::mesh::MetaData& meta_;

--- a/src/TiogaSTKIface.cpp
+++ b/src/TiogaSTKIface.cpp
@@ -459,17 +459,18 @@ void TiogaSTKIface::register_solution(const int nvars)
         tb->register_solution(tg_, nvars);
 }
 
-void TiogaSTKIface::update_solution(const int nvars)
+void TiogaSTKIface::update_solution(const int ncellVars, const int nnodeVars,
+    const int fieldSol, const int fringeSol)
 {
     auto tmon = get_timer("TiogaSTKIface::update_solution");
     double maxNormField, maxNormFringe = -1.0e20;
     double g_maxNormField, g_maxNormFringe = -1.0e20;
     for (auto& tb: blocks_)
     {
-        double normField = tb->update_solution(nvars, true);
+        double normField = tb->update_solution(ncellVars, nnodeVars, true, fieldSol);
         maxNormField = std::max(normField, maxNormField);
 
-        double normFringe = tb->update_solution(nvars, false);
+        double normFringe = tb->update_solution(ncellVars, nnodeVars, false, fringeSol);
         maxNormFringe = std::max(normFringe, maxNormFringe);
     }
 

--- a/src/TiogaSTKIface.h
+++ b/src/TiogaSTKIface.h
@@ -88,7 +88,7 @@ public:
   void register_solution(const int);
 
   //! Update solution field
-  void update_solution(const int);
+  void update_solution(const int, const int, const int, const int);
 
   /** Return the TIOGA interface object */
   TIOGA::tioga& tioga_iface()

--- a/src/amr/TiogaAMRIface.cpp
+++ b/src/amr/TiogaAMRIface.cpp
@@ -296,8 +296,10 @@ void TiogaAMRIface::update_solution(const bool isField)
         }
     }
 
-    rnorm /= static_cast<amrex::Real>(counter);
-    rnorm = std::sqrt(rnorm);
+    if(counter > 0) {
+        rnorm /= static_cast<amrex::Real>(counter);
+        rnorm = std::sqrt(rnorm);
+    }
     amrex::ParallelDescriptor::ReduceRealMax(
         rnorm, amrex::ParallelDescriptor::IOProcessorNumber());
     if (isField) {

--- a/src/amr/TiogaAMRIface.h
+++ b/src/amr/TiogaAMRIface.h
@@ -43,6 +43,8 @@ public:
 private:
     void init_var(Field&, const int nvars, const amrex::Real offset);
 
+    void update_solution(const bool isField);
+
     std::unique_ptr<StructMesh> m_mesh;
 
     //! Reference to cell variable field

--- a/src/amr/TiogaAMRIface.h
+++ b/src/amr/TiogaAMRIface.h
@@ -40,8 +40,14 @@ public:
 
     int num_node_vars() const { return m_nnode_vars; }
 
+    int stk_sol() const { return m_stk_sol; }
+
+    int amr_sol() const { return m_amr_sol; }
+
 private:
     void init_var(Field&, const int nvars, const amrex::Real offset);
+
+    double get_sol(const double, const double, const double, const int, const int);
 
     void update_solution(const bool isField);
 
@@ -71,6 +77,12 @@ private:
 
     //! Reals per grid for TIOGA call
     static constexpr int reals_per_grid{6};
+
+    //! Analytical solution profile for stk meshes
+    int m_stk_sol{1};
+
+    //! Analytical solution profile for amr meshes
+    int m_amr_sol{1};
 };
 
 }


### PR DESCRIPTION
This pull request introduces the ability to compute separate error norms for field and fringe points using separate analytical solutions as set by the user for the `amr` and `stk` meshes. Known discrepancies are encountered if the problem is run in parallel and there is a fringe/field mismatch for shared nodes across processor boundaries. Since this framework assumes that an `amr` mesh is donating to the `stk` meshes and vice-versa, if `amr_sol` and `stk_sol` are chosen to not be the same, discrepancies may arise in the error norm computations if an `stk` mesh is donating to another `stk` mesh. 